### PR TITLE
fix batch_dot.

### DIFF
--- a/reco_utils/recommender/newsrec/models/layers.py
+++ b/reco_utils/recommender/newsrec/models/layers.py
@@ -234,6 +234,7 @@ class SelfAttention(layers.Layer):
         A = K.batch_dot(Q_seq, K_seq, axes=[3, 3]) / K.sqrt(
             K.cast(self.head_dim, dtype="float32")
         )
+        A = K.reshape(A, shape=(-1, self.multiheads, K.shape(Q_seq)[1], K.shape(K_seq)[1]))
         A = K.permute_dimensions(
             A, pattern=(0, 3, 2, 1)
         )  # A.shape=[batch_size,K_sequence_length,Q_sequence_length,self.multiheads]
@@ -249,6 +250,7 @@ class SelfAttention(layers.Layer):
         A = K.softmax(A)
 
         O_seq = K.batch_dot(A, V_seq, axes=[3, 2])
+        O_seq = K.reshape(O_seq, shape=(-1, K.shape(A)[1], self.multiheads, K.shape(V_seq)[1]))
         O_seq = K.permute_dimensions(O_seq, pattern=(0, 2, 1, 3))
 
         O_seq = K.reshape(O_seq, shape=(-1, K.shape(O_seq)[1], self.output_dim))


### PR DESCRIPTION
### Description
The batch_dot function in keras.backend has different behavior in 1.x versus 2.2+. Per the following link. 
https://github.com/keras-team/keras/issues/13300
Added reshape to simulate the old behavior.